### PR TITLE
Set About overflow to hidden

### DIFF
--- a/style.css
+++ b/style.css
@@ -437,6 +437,7 @@ body {
 
 .about-caption {
   width: 90%;
+  overflow-y: hidden;
 }
 
 .about-caption p {


### PR DESCRIPTION
This PR sets the overflow for the About section to hidden. 