### PR TITLE
Fix the Nav menu close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </div>
         <div class="popover" id="menu">
           <div class="content">
-            <a href="#" class="close"></a>
+            <a href="#do_not_jump" onclick="method()" class="close"></a>
             <div class="nav">
               <ul class="nav-list">
                 <li class="nav-list-item"><a href="#">Home</a></li>


### PR DESCRIPTION
This PR prevents the close button of the navigation menu to jump to the top of the page on click. 